### PR TITLE
fix: fix YAML formatting errors in helm chart

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,62 +1,62 @@
 {{/*
   Expand the name of the chart.
   */}}
-  {{- define "wiki.name" -}}
-  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-  {{- end }}
-  
-  {{/*
-  Create a default fully qualified app name.
-  We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-  If release name contains chart name it will be used as a full name.
-  */}}
-  {{- define "wiki.fullname" -}}
-  {{- if .Values.fullnameOverride }}
-  {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-  {{- else }}
-  {{- $name := default .Chart.Name .Values.nameOverride }}
-  {{- if contains $name .Release.Name }}
-  {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-  {{- else }}
-  {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  
-  {{/*
-  Create chart name and version as used by the chart label.
-  */}}
-  {{- define "wiki.chart" -}}
-  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-  {{- end }}
-  
-  {{/*
-  Common labels
-  */}}
-  {{- define "wiki.labels" -}}
-  helm.sh/chart: {{ include "wiki.chart" . }}
-  {{ include "wiki.selectorLabels" . }}
-  {{- if .Chart.AppVersion }}
-  app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-  {{- end }}
-  app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{- end }}
-  
-  {{/*
-  Selector labels
-  */}}
-  {{- define "wiki.selectorLabels" -}}
-  app.kubernetes.io/name: {{ include "wiki.name" . }}
-  app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- end }}
-  
-  {{/*
-  Create the name of the service account to use
-  */}}
-  {{- define "wiki.serviceAccountName" -}}
-  {{- if .Values.serviceAccount.create }}
-  {{- default (include "wiki.fullname" .) .Values.serviceAccount.name }}
-  {{- else }}
-  {{- default "default" .Values.serviceAccount.name }}
-  {{- end }}
-  {{- end }}
+{{- define "wiki.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wiki.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wiki.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "wiki.labels" -}}
+helm.sh/chart: {{ include "wiki.chart" . }}
+{{ include "wiki.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wiki.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wiki.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wiki.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "wiki.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -37,7 +37,9 @@ spec:
               value: {{ default "1" .Values.postgres.NODE_TLS_REJECT_UNAUTHORIZED | quote }}
             - name: HA_ACTIVE
               value: {{ .Values.replicaCount | int | le 2 | quote }}
+            {{- if Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
+            {{- end }}
     {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
@@ -70,3 +72,4 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+


### PR DESCRIPTION
- The two spaces at the start of every line in the _helpers.tpl file caused extra indentation in the resultant YAML file in unexpectated spaces, causing parsing errors.  Removed.
- The inclusion of `.Values.env` in deployment.yaml was done without checking for the existence of it first.  In cases where env didn't exist, this would return the string `null`, which caused a parsing error.  Added a conditional to check for the existence of `.Values.env`.